### PR TITLE
Mehr Komma für die Zitate

### DIFF
--- a/modules/stoll.py
+++ b/modules/stoll.py
@@ -48,7 +48,7 @@ def stoll(phenny, input):
     "Da unser Universum ein ewig existierendes Zirkulationssystem darstellt, findet der sogenannte Urknall jederzeit statt.",
     "Die Masse eines Körpers entspricht dem Gesamt-Volumen seiner Atomkerne, also dem Gesamt-Volumen seiner 'Mini-Schwarzen Löcher'.",
     "Sein spezifisches Gewicht ist das Verhältnis des Volumens seiner 'Mini-Schwarzen Löcher' zu seinem Gesamtvolumen bei einer bestimmten Temperatur und relativ zu Wasser.",
-    "Wie erwähnt, steckt in τ ein rechtsrotierender (zum jeweiligen imaginären Mittelpunkt zielender), spiralförmiger Kraftverlauf."
+    "Wie erwähnt, steckt in τ ein rechtsrotierender (zum jeweiligen imaginären Mittelpunkt zielender), spiralförmiger Kraftverlauf.",
     "Die kleinen τ-freien Räume (die Atomkerne) erscheinen uns allgemein nur dann als Licht, wenn ihre Atome entbunden werden bzw. sich zerlegen.",
     "Zu beachten ist, dass wir in einer virtuellen Scheinwelt leben. Das bedeutet, dass wir nur die entsprechende Dichte der Schwingungen (Frequenzen) als unterschiedliche Aggregatzustände wahrnehmen!",
     "Strom ist nichts weiter als ausgeschiedene bzw. überschüssige Geschwindigkeit.",

--- a/modules/stoll.py
+++ b/modules/stoll.py
@@ -41,9 +41,9 @@ def stoll(phenny, input):
     "Tachyoneutrinos beinhalten den Terminus Tachyon(en) und Neutrino(s). Ersterer enthält die wichtige limitierende physikalische Größe Zeit und Geschwindigkeit (=Bewegung) und letzterer einen 'Schwingungs-Frequenz-Wirbelquant'!",
     "Ein Atom z.B. ähnelt nicht nur einer Sprungfeder, sondern es verfügt auch über ähnliche Eigenschaften, außer dass es mit hoher Geschwindigkeit rotiert.",
     "Dieses Gebilde kennen wir nur als sogenanntes 'Schwarzes Loch'! So, wie aber beispielsweise Luzifer nicht der Teufel, sondern der Lichtbringer ist (lux = das Licht), so ist 'unser' Jenseits-Raum (Τ-freier Raum) pures Licht!!",
-    "Eine große ΦM-Dichte führt der menschlichen Zelle soviel Energie zu, dass er nur langsam altert."
+    "Eine große ΦM-Dichte führt der menschlichen Zelle soviel Energie zu, dass er nur langsam altert.",
     "Wie im ... beschrieben, so ist die Zeit (T) physikalisch nichts weiter als universale Dichte in Korrelation mit der Raumbewegung.",
-    "Implosions- und Expansionsstrudel sind zwar miteinander korrelierend, verfügen aber über eine unterschiedliche energetische Struktur."
+    "Implosions- und Expansionsstrudel sind zwar miteinander korrelierend, verfügen aber über eine unterschiedliche energetische Struktur.",
     "Unser Universum ist das klassische 'Perpetuum Mobile' weil es aus sich selbst heruas existiert bzw. lebt.",
     "Da unser Universum ein ewig existierendes Zirkulationssystem darstellt, findet der sogenannte Urknall jederzeit statt.",
     "Die Masse eines Körpers entspricht dem Gesamt-Volumen seiner Atomkerne, also dem Gesamt-Volumen seiner 'Mini-Schwarzen Löcher'.",


### PR DESCRIPTION
da fehlen noch ein paar Kommas, deren Abwesenheit python ermächtigt, Zitate zusammenzuziehen, die nicht zusammen gehören.
